### PR TITLE
Add rapidfuzz 1.9.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+
+aggregate_check: false
+
+upload_channels:
+  - forklift
+
+channels:
+  - services
+  - forklift

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,9 +1,0 @@
-
-aggregate_check: false
-
-upload_channels:
-  - forklift
-
-channels:
-  - services
-  - forklift

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rapidfuzz" %}
-{% set version = "2.11.1" %}
+{% set version = "2.13.7" %}
 
 package:
   name: {{ name|lower }}
@@ -7,20 +7,16 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 61152fa1e3df04b4e748f09338f36ca32f7953829f4e630d26f7f564f4cb527b
+  sha256: 8d3e252d4127c79b4d7c2ae47271636cbaca905c8bb46d80c7930ab906cf4b5c
 
 build:
   number: 0
+  skip: True  # [py<37]
   script:
-    - {{ PYTHON }} -m pip install . -vvv
-  # fail to find the correct head path for Python. This will hopefully improve in scikit-build at some point
-  skip: true  # [python_impl == 'pypy' and linux and (aarch64 or ppc64le)]
+    - {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake
@@ -31,19 +27,18 @@ requirements:
     - scikit-build
     - wheel
     - setuptools
-    - rapidfuzz_capi
   run:
-    - jarowinkler
     - python
     - {{ pin_compatible('numpy') }}
 
 test:
   imports:
     - rapidfuzz
-  commands:
-    - pip check
+    - rapidfuzz.distance
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/maxbachmann/RapidFuzz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,8 @@ build:
   skip: True  # [py<37]
   script:
     - {{ PYTHON }} -m pip install . -vvv
+  missing_dso_whitelist:  # [s390x]
+    - '$RPATH/ld64.so.1'  # [s390x]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - make
+    - python
   host:
     - pip
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rapidfuzz" %}
-{% set version = "2.13.7" %}
+{% set version = "1.9.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,27 +7,26 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 8d3e252d4127c79b4d7c2ae47271636cbaca905c8bb46d80c7930ab906cf4b5c
+  sha256: bd7a4fe33ba49db3417f0f57a8af02462554f1296dedcf35b026cd3525efef74
 
 build:
   number: 0
   skip: True  # [py<37]
   script:
-    - {{ PYTHON }} -m pip install . -vv --no-deps
+    - {{ PYTHON }} -m pip install . -vvv
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - cmake
-    - make
-    - python
   host:
-    - pip
     - python
-    - scikit-build
-    - wheel
+    - pip
+    - numpy   1.19   # [py<310]
+    - numpy   1.21   # [py==310]
+    - numpy   1.23   # [py>=311]
     - setuptools
+    - wheel
   run:
     - python
     - {{ pin_compatible('numpy') }}
@@ -35,7 +34,6 @@ requirements:
 test:
   imports:
     - rapidfuzz
-    - rapidfuzz.distance
   requires:
     - pip
   commands:


### PR DESCRIPTION
Changelog: https://github.com/maxbachmann/RapidFuzz/blob/v1.9.1/CHANGELOG.rst
License:
Requirements:
- https://github.com/maxbachmann/RapidFuzz/blob/v1.9.1/pyproject.toml
- https://github.com/maxbachmann/RapidFuzz/blob/v1.9.1/setup.py
- https://github.com/maxbachmann/RapidFuzz/blob/v1.9.1/setup.cfg

Actions:
1. Skip py<37
2. Add --no-deps
3. Remove cross-platfrom dependencies from build
4. Remove rapidfuzz_capi from host
5. Remove jarowinkler from run
6. Add rapidfuzz.distance to test/imports

Notes:

- grayskull requires rapidfuzz >=1.7.1 https://github.com/AnacondaRecipes/grayskull-feedstock/pull/1, but rapidfuzz versions `>=2.0.0` have `scikit-build` for building the package and it causes an error `Could NOT find Python (missing: Interpreter Development.Module)`. Seems like the issue was described here https://github.com/maxbachmann/RapidFuzz/issues/232#issuecomment-1166432806.
- Later we can update rapidfuzz to the latest version but now for unblocking grayskull will be enough rapidfuzz 1.9.1

